### PR TITLE
Fix recent deps warning

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,2 @@
 {:paths ["src"]
- :deps {cljs-bean {:mvn/version "1.5.0"}}}
+ :deps {cljs-bean/cljs-bean {:mvn/version "1.5.0"}}}


### PR DESCRIPTION
Recent versions of deps trigger a warning when dependencies don't have a namespace:

```
DEPRECATED: Libs must be qualified, change cljs-bean => cljs-bean/cljs-bean (.../helix/deps.edn)
````