### PR TITLE
Ignore quoted forms when searching for hooks

### DIFF
--- a/test/helix/impl/analyzer_test.clj
+++ b/test/helix/impl/analyzer_test.clj
@@ -41,7 +41,9 @@
         '(condp = (use-foo)
            bar (baz))
         '(condp = asdf
-           (use-foo) (baz))))
+           (use-foo) (baz))
+        '(when true
+           '(use-foo))))
     (t/testing "incorrect hooks usage in branch"
       (t/are [form] (seq (hana/invalid-hooks-usage form))
         '(if (foo)
@@ -169,3 +171,11 @@
       'user
       'foo/use
       'foo/user)))
+
+(t/deftest find-hooks
+  (t/are [hooks body] (= hooks (hana/find-hooks body))
+         [] '(do '(use-foo))
+         '[(use-foo)] '(use-foo)
+         '[(use-foo)] '{:foo (use-foo)}
+         '[(use-foo)] '{:foo #{use-bar (use-foo)}}
+         '[] '('use-foo bar)))


### PR DESCRIPTION
Previously, a component containing a quoted form with a hook in would
have been caught by the hooks detection (example below).  Additionally,
avoiding the postwalk improves the performance of the find-hooks
function.

```
(defnc foo
  []
  (d/div
    (d/h1 "Usage example")
    (d/code (pr-str '(use-foo)))))
```