### PR TITLE
Add defnc- to define private component definitions

### DIFF
--- a/src/helix/core.clj
+++ b/src/helix/core.clj
@@ -273,6 +273,12 @@
          ~display-name)))
 
 
+(defmacro defnc-
+  "Same as defnc, yielding a non-public def"
+  [display-name & rest]
+  (list* 'defnc (vary-meta display-name assoc :private true) rest))
+
+
 ;;
 ;; Custom hooks
 ;;

--- a/test/helix/core_test.cljs
+++ b/test/helix/core_test.cljs
@@ -2,7 +2,7 @@
   (:require
     [cljs.test :as t :include-macros true]
     [goog.object :as gobj]
-    [helix.core :as helix :refer (defnc $)]))
+    [helix.core :as helix :refer (defnc defnc- $)]))
 
 
 (t/deftest metadata-optimization-expansion
@@ -39,3 +39,15 @@
       (t/is (= key (gobj/get el "key")))
       (t/is (= (dissoc props :key :ref)
                (helix/extract-cljs-props (gobj/get el "props")))))))
+
+
+(defnc- private-comp
+  {:foo :bar}
+  []
+  "can't see me outside of this namespace!")
+
+(t/deftest private-component-definition
+  (let [metadata (meta #'private-comp)]
+    (t/is (:private metadata))
+    (t/is (= (:foo metadata) :bar))))
+


### PR DESCRIPTION
Issue: #82 defnc- to create private component definitions

- Adds :private true to display-name
- Tests that private is added
- Tests to make sure existing metadata isn't overwritten