### PR TITLE
add check for IStateUpdater protocol before applying spread-updater

### DIFF
--- a/src/helix/hooks.cljc
+++ b/src/helix/hooks.cljc
@@ -26,10 +26,21 @@
        (def raw-use-imperative-handle react/useImperativeHandle)))
 
 
+(defprotocol IStateUpdater
+  "Protocol that marks a type as callable when passed to a use-state setter.")
+
+
+#?(:cljs
+   (extend-protocol IStateUpdater
+     MultiFn ;; multimethods
+     function))
+
+
 #?(:cljs
    (defn use-state
      "Like `react/useState`, but the update function returned can be used similar
-  to `swap!`.
+  to `swap!` if the first argument implements `IStateUpdater`.
+  By default, this includes functions and multimethods.
 
   Example:
   ```
@@ -42,8 +53,13 @@
            updater (react/useCallback (fn updater
                                         ([x] (u x))
                                         ([f & xs]
-                                         (updater (fn spread-updater [x]
-                                                    (apply f x xs)))))
+                                         (if (satisfies? IStateUpdater f)
+                                           (updater (fn spread-updater [x]
+                                                      (apply f x xs)))
+                                           ;; if the first argument isn't valid
+                                           ;; updater, then call `u` with it
+                                           ;; ignoring other args
+                                           (u f))))
                                       ;; `u` is guaranteed to be stable so we elide it
                                       #js [])]
        [v updater])))


### PR DESCRIPTION
This potentially fixes an issue where when passing in the setter function returned by use-state, the setter is accidentally passed two arguments and attempts to call `(apply arg1 ,,,)`, leading to runtime errors.

Example:
```clojure
(defnc my-component
  []
  (let [[state set-state] (hooks/use-state 0)]
    ($ some-other-component {:on-event set-state})))
```

If the handler passed into `:on-event` gets called with two arguments, then this will fail at runtime with a hard to debug error.

With this PR, the behavior instead will be that the `set-state` function will check to see if the first argument is either a function, a multimethod or if implements a special protocol. If it matches one of those, then it will do as it does today and try and call it like a function just like `swap!`. If it does not match one of those, then it will set the state to be whatever the first argument is and ignore the rest of the arguments.