### PR TITLE
add ^js hint to react context

### DIFF
--- a/src/helix/core.clj
+++ b/src/helix/core.clj
@@ -72,11 +72,13 @@
 
     (provider {:context my-context :value my-value} child1 child2 ...childN)"
   [{:keys [context value] :as props} & children]
-  `^js/React.Element ($ (.-Provider ~context)
-                        ;; use contains to guard against `nil`
-                        ~@(when (contains? props :value)
-                            `({:value ~value}))
-                        ~@children))
+  (let [ctx (vary-meta (gensym "ctx") assoc :tag 'js)]
+    `(let [~ctx ~context]
+       ^js/React.Element ($ (.-Provider ~ctx)
+                            ;; use contains to guard against `nil`
+                            ~@(when (contains? props :value)
+                                `({:value ~value}))
+                            ~@children))))
 
 
 (defmacro suspense


### PR DESCRIPTION
Fixes #103 

I don't know a cleaner way to add a type hint to a symbol inside a macro.  If you have a better way to do this, I would love to know!