### PR TITLE
Use syntax quote for `defnc` in `defnc-`

### DIFF
--- a/src/helix/core.clj
+++ b/src/helix/core.clj
@@ -276,7 +276,7 @@
 (defmacro defnc-
   "Same as defnc, yielding a non-public def"
   [display-name & rest]
-  (list* 'defnc (vary-meta display-name assoc :private true) rest))
+  (list* `defnc (vary-meta display-name assoc :private true) rest))
 
 
 ;;


### PR DESCRIPTION
Otherwise `defnc` will not resolve when users only refer `defnc-`.

Consider the following example:

```clojure
(ns example.core
  (:require ["react" :as react]
            ["react-dom" :as react-dom]
            [helix.core :refer [$ defnc-]]))

(defnc- my-component []
  ($ "h1" "Hello, World!"))
  
(defn render []
  (react-dom/render ($ my-component) (.getElementById js/document "app")))
```

Currently, this will fail to compile since the `defnc-` macro expands to `defnc` which is not defined in this context.