### PR TITLE
fix indentation of else-block

### DIFF
--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -24,7 +24,7 @@
                  (some? (.match name-str aria-data-css-custom-prop-special-case-re)) name-str
                  (= (.substring name-str 0 1) "'") (.substring name-str 1)
                  :else (.replace name-str camel-regexp #(.toUpperCase %2)))))
-      s))
+    s))
 
 (comment
   (camel-case "get-asdf-aw9e8f"))


### PR DESCRIPTION
Fixed indentation of the last line so it doesn’t look like it’s inside `let`, but is the last `if` arg:

https://github.com/lilactown/helix/blob/master/src/helix/impl/props.cljc#L14-L27