### PR TITLE
docs/creating-components: explain `defcomponent` and provide example

### DIFF
--- a/docs/creating-components.md
+++ b/docs/creating-components.md
@@ -117,4 +117,36 @@ use the `fnc` macro.
 
 ## Class Components
 
-WIP
+**Note:** Consider class components as a "last resort" action for cases where a
+function component cannot be used.
+
+The `defcomponent` macro accepts a symbol together with a list of methods or
+properties. Methods are written with the syntax `(name [this args] body)`.
+Properties are written with the syntax `(name form)`. To mark a method as
+static, use the `^:static` metadata.
+
+### Error Boundary Example
+
+As of React 18, there is still no way to write an error boundary as a function
+component. Here is how we could implement an error boundary with Helix.
+
+```clj
+(defcomponent ErrorBoundary
+  ;; To avoid externs inference warnings, we annotate `this` with ^js whenever
+  ;; accessing a method or field of the object.
+  (constructor [^js this]
+    (set! (.-state this) #js {:hasError false}))
+
+  (componentDidCatch [^js this error _info]
+    (.setState this #js {:data error}))
+
+  ^:static (getDerivedStateFromError [_this _error]
+              #js {:hasError true})
+
+  (render [^js this]
+    (if (.. this -state -hasError)
+      (d/pre
+        (d/code
+          (pr-str (.. this -state -data))))
+      (.. this -props -children))))
+```

--- a/docs/creating-components.md
+++ b/docs/creating-components.md
@@ -143,10 +143,10 @@ component. Here is how we could implement an error boundary with Helix.
   ^:static (getDerivedStateFromError [_this _error]
               #js {:hasError true})
 
-  (render [^js this]
-    (if (.. this -state -hasError)
+  (render [^js this props ^js state]
+    (if (.-hasError state)
       (d/pre
         (d/code
-          (pr-str (.. this -state -data))))
-      (.. this -props -children))))
+          (pr-str (.-data state))))
+      (:children props))))
 ```


### PR DESCRIPTION
I have recently stumbled upon the need to create class components with Helix, because I wanted to create an error boundary. I've known that the Class Components documentation has been WIP for a while. So I have decided to provide a brief explanation of the `defcomponent` macro and provide a simple implementation of an error boundary.