### PR TITLE
helix.hooks: introduce use-id

### DIFF
--- a/src/helix/hooks.cljc
+++ b/src/helix/hooks.cljc
@@ -414,3 +414,8 @@
 
          ;; If parameters haven't changed, return value stored in state
          (gobj/get state "value")))))
+
+#?(:cljs
+   (def use-id
+     "Equivalent to react/useId"
+     react/useId))

--- a/test/helix/hooks_test.cljs
+++ b/test/helix/hooks_test.cljs
@@ -1,0 +1,17 @@
+(ns helix.hooks-test
+  "Namespace containing tests for hooks wrappers."
+  (:require [cljs.test :as t]
+            [helix.core :refer [$ defnc]]
+            [helix.hooks :as hooks]
+            ["react-dom/server" :as rds]))
+
+;;; useId hook test
+
+(defnc use-id-example []
+  (let [id (hooks/use-id)]
+    (str "Generated identifier: " id)))
+
+(t/deftest use-id-test
+  (t/testing "whether components invoking use-id render correctly"
+    (t/is (= "Generated identifier: :R0:"
+             (rds/renderToString ($ use-id-example))))))


### PR DESCRIPTION
**Motivation**
Although `gensym` already exist in Clojure, I find it useful to have this hook for two reasons:
* completeness; the `helix.hooks` namespace is nice because it has autocomplete and consistent casing with other Clojure functions
* `gensym`, while useful on the client-side, can cause hydration mismatch

So I went ahead and added the hook, together with a basic unit test for this hook and future wrappers over React hooks.

**Caveats**
`useId` was introduced in React 18. This code bumps the minimum required React to version 18.