### PR TITLE
Use the modern JSX transform (closes #123)

### DIFF
--- a/dev/workshop/core.cljs
+++ b/dev/workshop/core.cljs
@@ -358,11 +358,11 @@
                       (simple-benchmark
                        []
                        (rds/renderToString
-                        (r/createElement
-                         react-children-benchmark
-                         #js {:foo "bar"}
-                         (r/createElement "div" #js {:style #js {:backgroundColor "green"}} "foo")
-                         (r/createElement "div" nil "bar")))
+                        (helix/jsxs react-children-benchmark
+                                    #js {:foo "bar"
+                                         :children #js [(helix/jsx "div" #js {:style #js {:backgroundColor "green"}
+                                                                              :children "foo"})
+                                                        (helix/jsx "div" #js {:children "bar"})]}))
                        iterations)))
 
         helix-time (hooks/use-memo

--- a/src/helix/core.clj
+++ b/src/helix/core.clj
@@ -67,8 +67,7 @@
                    (contains? (first args) :key))
         the-key (when has-key?
                   (:key (first args)))
-        emit-fn (if (and (seq? children)
-                         (next children))
+        emit-fn (if (next children)
                   `jsxs
                   `jsx)]
     (if has-key?

--- a/src/helix/core.clj
+++ b/src/helix/core.clj
@@ -2,8 +2,14 @@
   (:require
    [helix.impl.analyzer :as hana]
    [helix.impl.props :as impl.props]
+   [cljs.tagged-literals :as tl]
    [clojure.string :as string]))
 
+(defn- jsx-children [coll]
+  (let [s (seq coll)]
+    (if (and s (next s))
+      (tl/->JSValue coll)
+      (first coll))))
 
 (defmacro $
   "Create a new React element from a valid React type.
@@ -44,19 +50,30 @@
                     (:native (meta type)))
         type (if (keyword? type)
                (name type)
-               type)]
-    (cond
-      (map? (first args))
-      `^js/React.Element (.createElement
-                          (get-react)
-                          ~type
-                          ~(if native?
-                             `(impl.props/dom-props ~(first args))
-                             `(impl.props/props ~(first args)))
-                          ~@(rest args))
-
-      :else `^js/React.Element (.createElement (get-react) ~type nil ~@args))))
-
+               type)
+        has-props? (or (map? (first args))
+                       (nil? (first args)))
+        children (if has-props?
+                   (rest args)
+                   args)
+        props (if (map? (first args))
+                (if native?
+                  `(impl.props/dom-props ~(first args) ~(jsx-children children))
+                  `(impl.props/props     ~(first args) ~(jsx-children children)))
+                (tl/->JSValue (cond-> {}
+                                (not-empty children)
+                                (assoc :children (jsx-children children)))))
+        has-key? (when has-props?
+                   (contains? (first args) :key))
+        the-key (when has-key?
+                  (:key (first args)))
+        emit-fn (if (and (seq? children)
+                         (next children))
+                  `jsxs
+                  `jsx)]
+    (if has-key?
+      `^js/React.Element (~emit-fn ~type ~props ~the-key)
+      `^js/React.Element (~emit-fn ~type ~props))))
 
 (defmacro <>
   "Creates a new React Fragment Element"

--- a/src/helix/core.cljs
+++ b/src/helix/core.cljs
@@ -73,7 +73,7 @@
                 (impl.props/-dom-props props*)
                 (impl.props/-props     props*))
         key (:key props*)
-        emit-fn (if (and children* (next children*))
+        emit-fn (if (next children*)
                   jsxs
                   jsx)
         type' (if (keyword? type)

--- a/src/helix/core.cljs
+++ b/src/helix/core.cljs
@@ -63,7 +63,7 @@
         children* ^seq (if has-props?
                          ?c
                          args)
-        children (if (and children* (next children*))
+        children (if (next children*)
                    (into-array children*)
                    (first children*))
         props* (cond-> {}

--- a/src/helix/dom.cljc
+++ b/src/helix/dom.cljc
@@ -167,7 +167,7 @@
         children* (if has-props?
                     (rest args)
                     args)
-        multiple-children (and children* (next children*))
+        multiple-children (next children*)
         children (if multiple-children
                    (tl/->JSValue children*)
                    (first children*))

--- a/src/helix/dom.cljc
+++ b/src/helix/dom.cljc
@@ -1,6 +1,7 @@
 (ns helix.dom
   (:refer-clojure :exclude [map meta time])
   (:require
+   [cljs.tagged-literals :as tl]
    [helix.core :as hx]
    [helix.impl.props :as impl.props])
   #?(:cljs (:require-macros [helix.dom])))
@@ -161,18 +162,23 @@
 
   Use the special & or :& prop to merge dynamic props in."
   [type & args]
-  (if (map? (first args))
-    `^js/React.Element (.createElement
-                        (hx/get-react)
-                        ~type
-                        (impl.props/dom-props ~(first args))
-                        ~@(rest args))
-    `^js/React.Element (.createElement
-                        (hx/get-react)
-                        ~type
-                        nil
-                        ~@args)))
-
+  (let [?p (first args)
+        has-props? (map? ?p)
+        children* (if has-props?
+                    (rest args)
+                    args)
+        multiple-children (and children* (next children*))
+        children (if multiple-children
+                   (tl/->JSValue children*)
+                   (first children*))
+        props* (when has-props? ?p)
+        key (:key props*)
+        emit-fn (if multiple-children
+                  `hx/jsxs
+                  `hx/jsx)]
+    (if (some? key)
+      `^js/React.Element (~emit-fn ~type (impl.props/dom-props ~props* ~children) ~key)
+      `^js/React.Element (~emit-fn ~type (impl.props/dom-props ~props* ~children)))))
 
 #?(:clj (defn gen-tag
           [tag]

--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -172,8 +172,11 @@
   (-dom-props {:style ["fs1"]})
   )
 
-(defmacro dom-props [m]
-  (-dom-props m))
+(defmacro dom-props
+  ([m] `(dom-props ~m nil))
+  ([m c] (-dom-props (cond-> m
+                       c    (assoc :children c)
+                       true (dissoc :key)))))
 
 
 (defn -props
@@ -205,5 +208,8 @@
   (-props {:foo-bar "baz"})
   )
 
-(defmacro props [m]
-  (-props m))
+(defmacro props
+  ([m] `(props ~m nil))
+  ([m c] (-props (cond-> m
+                   (some? c) (assoc :children c)
+                   true      (dissoc :key)))))

--- a/test/helix/impl/props_test.cljc
+++ b/test/helix/impl/props_test.cljc
@@ -143,7 +143,18 @@
                #js {:foo "bar"}))
 
      (t/is (eq (impl/dom-props {:style ["bar"]})
-               #js {:style #js ["bar"]}))))
+               #js {:style #js ["bar"]}))
+
+     (t/testing "children are added to props"
+       (t/is (eq (impl/dom-props nil "are the best")
+                 #js {:children "are the best"}))
+       (t/is (eq (impl/dom-props {} "are the best")
+                 #js {:children "are the best"}))
+       ;; Should we convert to JS???
+       (t/is (eq (impl/dom-props nil ["one" "two"])
+                 #js {:children ["one" "two"]}))
+       (t/is (eq (impl/dom-props {} ["one" "two"])
+                 #js {:children ["one" "two"]})))))
 
 
 #?(:cljs
@@ -183,7 +194,18 @@
 
      (t/is (eq (impl/props {:foo "bar"
                                    & nil})
-               #js {:foo "bar"}))))
+               #js {:foo "bar"}))
+
+     (t/testing "children are added to props"
+       (t/is (eq (impl/props nil "are the best")
+                 #js {:children "are the best"}))
+       (t/is (eq (impl/props {} "are the best")
+                 #js {:children "are the best"}))
+       ;; Should we convert to JS???
+       (t/is (eq (impl/props nil ["one" "two"])
+                 #js {:children ["one" "two"]}))
+       (t/is (eq (impl/props {} ["one" "two"])
+                 #js {:children ["one" "two"]})))))
 
 
 (t/deftest test-normalize-class


### PR DESCRIPTION
With the new transform, the `$` macro is technically no longer dependent on React. This possibly opens a path to Preact support in Helix.

More importantly, we obtain marginally faster performance. React is able to make optimizations that it otherwise can't with `React.createElement()`.

---

**Backwards compatibility**
While the new JSX transform was introduced in React 17, it has been backported to React 16.14.0, React 15.7.0, and React 0.14.10. This PR should not introduce any surprises to current users of Helix, unless they use outdated versions of React 16, 15, or 0.14.

**Pros**
- Marginally faster performance.
- Benefitting from future React optimizations

**Cons**
- Users on versions of React below 0.14.10 will no longer be able to use Helix. Users on outdated versions of React 0.14, 15, or 16 will no longer be able to use Helix.
- The logic of the `$` and `$d` macros are slightly more complicated. The logic of the `$` function is also more complicated. Unit tests are provided to ensure the output of `$` matches the modern JSX transform, but these tests may need maintenance.

