### PR TITLE
docs/pro-tips: Update defnc macro example for modern usages

### DIFF
--- a/docs/pro-tips.md
+++ b/docs/pro-tips.md
@@ -100,20 +100,26 @@ use it.
     [helix.core]))
 
 
-(defmacro defnc [type params & body]
-  (let [[docstring params body] (if (string? params)
-                                  [params (first body) (rest body)]
-                                  [nil params body])
-        opts? (map? (first body)) ;; whether an opts map was passed in
-        opts (if opts?
-               (first body)
-               {})
-        body (if opts?
-               (rest body)
-               body)
+(defmacro defnc [type & form-body]
+  (let [[docstring form-body] (if (string? (first form-body))
+                                [(first form-body) (rest form-body)]
+                                [nil form-body])
+        [fn-meta form-body] (if (map? (first form-body))
+                              [(first form-body) (rest form-body)]
+                              [nil form-body])
+        params (first form-body)
+        body (rest form-body)
+        opts-map? (map? (first body))
+        opts (cond-> (if opts-map?
+                       (first body)
+                       {})
+               (:wrap fn-meta) (assoc :wrap (:wrap fn-meta)))
         ;; feature flags to enable by default
         default-opts {:helix/features {:fast-refresh true}}]
-    `(helix.core/defnc ~type ~@(when docstring [docstring]) ~params
+    `(helix.core/defnc ~type
+       ~@(when docstring [docstring])
+       ~@(when fn-meta [fn-meta])
+       ~params
        ;; we use `merge` here to allow indidivual consumers to override feature
        ;; flags in special cases
        ~(merge default-opts opts)


### PR DESCRIPTION
The old custom macro does not support `fn-meta`. Attempts to use `fn-meta` with the old version will result in errors, since the custom macro will not insert code properly into `helix.core/defnc`.

To quickly test this, try something as simple as this:
```clojure
;;; Make sure you are using your own custom `defnc` macro!

(defnc FancyButton
  "Example lifted straight from React documentation."
  {:wrap [(react/forwardRef)]}
  [{:keys [children]} ref]
  (d/button {:ref ref :class "FancyButton"} children))

(defnc Parent []
  (let [ref (hooks/use-ref nil)]
    ($ FancyButton {:ref ref} "Click me!")))
```

You will get compile error when using the old custom macro, but not the updated one I provide in this PR.