### PR TITLE
Introduce helix.core/create-ref, a wrapper around createRef

### DIFF
--- a/dev/workshop/core.cljs
+++ b/dev/workshop/core.cljs
@@ -235,6 +235,17 @@
   (<> ($ class-component {:foo "bar"})
       ($ ClassComponent {:foo "baz"})))
 
+(helix/defcomponent RefTest
+  (constructor [^js this]
+    (set! (.-myRef this) (helix/create-ref)))
+  (focusInput [^js this]
+    (.focus @(.-myRef this)))
+  (render [^js this props state]
+    (d/div
+     (d/input {:type "text" :ref (.-myRef this)})
+     (d/input {:type "button" :value "Focus" :onClick (.-focusInput this)}))))
+
+(dc/defcard ref ($ RefTest))
 
 (helix/defhook use-custom-effect
   [deps f]

--- a/src/helix/core.cljs
+++ b/src/helix/core.cljs
@@ -217,6 +217,39 @@
 
   (rds/renderToString ($$ MyComponent {:foo "baz"})))
 
+(defn create-ref
+  "Like react/createRef, but the ref can be swapped, reset, and dereferenced
+  like an atom.
+
+  Note: `helix.core/create-ref` is mostly used for class components. Function
+  components typically rely on `helix.hooks/use-ref` instead."
+
+  ([]
+   (create-ref nil))
+
+  ([initial-value]
+   (let [^js ref (react/createRef)]
+     (set! (.-current ref)
+           (specify! #js {:current initial-value}
+             IDeref
+             (-deref [^js this]
+               (.-current this))
+
+             IReset
+             (-reset! [^js this x]
+               (set! (.-current this) x))
+
+             ISwap
+             (-swap!
+               ([^js this f]
+                (set! (.-current this) (f (.-current this))))
+               ([^js this f a]
+                (set! (.-current this) (f (.-current this) a)))
+               ([^js this f a b]
+                (set! (.-current this) (f (.-current this) a b)))
+               ([^js this f a b xs]
+                (set! (.-current this) (apply f (.-current this) a b xs))))))
+     (.-current ref))))
 
 ;;
 ;; -- React Fast Refresh

--- a/test/helix/core_test.cljs
+++ b/test/helix/core_test.cljs
@@ -70,3 +70,23 @@
   (let [metadata (meta #'private-comp)]
     (t/is (:private metadata))
     (t/is (= (:foo metadata) :bar))))
+
+(t/deftest ref-test
+  (let [ref (helix/create-ref 4649)]
+    (t/testing "ref"
+      (t/testing "can be initialized with value"
+        (t/is (= 4649 (.-current ref))))
+      (t/testing "can be used with IDeref"
+        (t/is (= 4649 @ref)))
+      (t/testing "can be used with ISwap"
+        (swap! ref (constantly 0)) ; 0
+        (t/is (zero? @ref))
+        (swap! ref + 1)            ; (+ 0 1)
+        (t/is (= 1 @ref))
+        (swap! ref + 1 2)          ; (+ 0 1 1 2)
+        (t/is (= 4 @ref))
+        (swap! ref + 1 2 3)        ; (+ 0 1 1 2 1 2 3)
+        (t/is (= 10 @ref)))
+      (t/testing "can be used with IReset"
+        (reset! ref "well done")
+        (t/is (= "well done" @ref))))))


### PR DESCRIPTION
This commit introduces a function that produces a ref that can be used with the atom protocols (namely, IDeref, IReset, and ISwap). Unit tests and a devcards demonstration are also provided.

Fixes #131 