### PR TITLE
helix.hooks: make wrap-fx private

### DIFF
--- a/src/helix/hooks.cljc
+++ b/src/helix/hooks.cljc
@@ -120,7 +120,7 @@
 
 ;; React `useEffect` expects either a function or undefined to be returned
 #?(:cljs
-   (defn wrap-fx [f]
+   (defn- wrap-fx [f]
      (fn wrap-fx-return []
        (let [x (f)]
          (if (fn? x)


### PR DESCRIPTION
Fixes #127

No compiler warnings are emitted when compiling the `:dev` and `:test` targets. There is a risk of this change breaking 3rd party code calling `wrap-fx` explicitly, but I cannot think of a use case for this function outside of the `use-effect` implementation.