### PR TITLE
helix.core: rewrite symbol so that `exists?` emits correct code

### DIFF
--- a/src/helix/core.cljs
+++ b/src/helix/core.cljs
@@ -261,11 +261,11 @@
   `type` is the component function, and `id` is the unique ID assigned to it
   (e.g. component name) for cache invalidation."
   [type id]
-  (when (exists? (.-$$Register$$ js/window))
-    (.$$Register$$ js/window type id)))
+  (when (exists? js/window.$$Register$$)
+    (js/window.$$Register$$ type id)))
 
 
 (defn signature! []
   ;; grrr `maybe` bug strikes again
-  (and (exists? (.-$$Signature$$ js/window))
-       (.$$Signature$$ js/window)))
+  (and (exists? js/window.$$Register$$)
+       (js/window.$$Signature$$)))


### PR DESCRIPTION
Fixes #136

The functions seem to behave as intended with a tiny project I made. So I think everything is fine.