### PR TITLE
Fix extension of js/Symbol in favour of primitive

### DIFF
--- a/src/helix/core.cljs
+++ b/src/helix/core.cljs
@@ -9,9 +9,9 @@
   (:require-macros [helix.core]))
 
 
-(when (exists? js/Symbol)
+(when (exists? symbol)
   (extend-protocol IPrintWithWriter
-    js/Symbol
+    symbol
     (-pr-writer [sym writer _]
       (-write writer (str "\"" (.toString sym) "\"")))))
 


### PR DESCRIPTION
Fixes warning on ClojureScript master

https://github.com/clojure/clojurescript/commit/6d9ba920ccd5c364df847a9633c1c6c614917981
https://clojure.atlassian.net/browse/CLJS-528
https://github.com/clojure/clojurescript/commit/df04ee2c41ce7683b52c5793d0154ca88771f0f7