### PR TITLE
Refine development setup

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+((nil . ((cider-default-cljs-repl . shadow)
+         (cider-shadow-default-options . "dev"))))

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 .clj-kondo/.cache
 .lsp/.cache
 .cpcache
+.make_npm
 
 # clojure-lsp will automatically copy the following from resources to here at runtime
 .clj-kondo/lilactown/helix/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: clean run
+.DEFAULT_GOAL := run
+
+clean:
+	rm -rf public/dev/js
+
+.make_npm: package.json
+	npm install --no-fund --no-audit --no-progress --loglevel=error
+	touch $@
+
+run: clean .make_npm
+	npm run shadow-cljs watch dev

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Other resources:
 
 [<img src="https://github.com/lilactown/helix/assets/2687140/76097c17-0458-4f2d-a3ec-dc64445d3771" alt="amperity_logo" style="width: 50px;">](https://amperity.com/)
 
+## Hacking on Helix
+
+By running `make run` you'll run a shadow-cljs development server that you can, for instance, `cider-connect-clj&cljs` to. 
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-refresh": "^0.13.0",
-    "shadow-cljs": "^2.15.12",
+    "shadow-cljs": "^2.25.8",
     "showdown": "^1.9.1"
+  },
+  "scripts": {
+    "shadow-cljs": "shadow-cljs"
   }
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -7,7 +7,12 @@
  :dependencies
  [[binaryage/devtools "0.9.7"]
   [devcards "0.2.5"]
+  [cider/cider-nrepl "0.40.0"]
+  [refactor-nrepl/refactor-nrepl "3.9.0"]
   [cljs-bean "1.5.0"]]
+
+ :middleware [cider.nrepl/cider-middleware
+              refactor-nrepl.middleware/wrap-refactor]
 
  :builds
  {:dev {:target :browser


### PR DESCRIPTION
Makes it easy to spin up a shadow-cljs dev server using a fixed shadow-cljs version (not easily shadowed by a global install), and cider-nrepl latest.

By using cider-nrepl 0.40.0, indentation issues are gone. (It didn't have to do with indentation inference, btw)

I found these tweaks handy for my own debugging, but they also look useful enough for contributors.

Cheers - V