### PR TITLE
Fix use of private wrap-fx in macro

### DIFF
--- a/src/helix/hooks.cljc
+++ b/src/helix/hooks.cljc
@@ -127,11 +127,6 @@
            x
            js/undefined)))))
 
-
-(defn simple-body? [body]
-  (and (= (count body) 1) (symbol? (first body))))
-
-
 #?(:clj
    (defn deps-macro-body [env deps body simple-body-ok? deps->hook-body]
      (cond

--- a/src/helix/impl/hooks.cljs
+++ b/src/helix/impl/hooks.cljs
@@ -1,0 +1,9 @@
+(ns helix.impl.hooks)
+
+;; React `useEffect` expects either a function or undefined to be returned
+(defn wrap-fx [f]
+  (fn wrap-fx-return []
+    (let [x (f)]
+      (if (fn? x)
+        x
+        js/undefined))))


### PR DESCRIPTION
This ends up expanding in the caller's namespace, which references the private `wrap-fx` and leads to a compiler warning under Figwheel.  I believe Shadow is suppressing these so it wasn't caught.
